### PR TITLE
replaced psutil.get_pid_list() by psutil.pids()

### DIFF
--- a/autoload/atplib/callback.vim
+++ b/autoload/atplib/callback.vim
@@ -412,7 +412,7 @@ import psutil
 var  = vim.eval("a:var")
 pids = vim.eval(var)
 if len(pids) > 0:
-    ps_list=psutil.get_pid_list()
+    ps_list=psutil.pids()
     rmpids=[]
     for lp in pids:
 	run=False

--- a/autoload/atplib/compiler.vim
+++ b/autoload/atplib/compiler.vim
@@ -342,7 +342,7 @@ latex = vim.eval("b:atp_TexCompiler")
 # Make dictionary: xpdf_servername : file
 # to test if the server host file use:
 # basename(xpdf_server_file_dict().get(server, ['_no_file_'])[0]) == basename(file)
-ps_list=psutil.get_pid_list()
+ps_list=psutil.pids()
 latex_running = False
 for pr in ps_list:
     try:
@@ -543,7 +543,7 @@ program = vim.eval("a:program")
 file_name = vim.eval("a:file")
 pat = "|".join(vim.eval("a:000"))
 x = False
-for pid in psutil.get_pid_list():
+for pid in psutil.pids():
     try:
         p = psutil.Process(pid)
         if psutil.version_info[0] >= 2:
@@ -1460,7 +1460,7 @@ def xpdf_server_file_dict():
 #    where get_filename is a simple program which returns the filename. 
 #    Then if the file matches I can just reload, if not I can use:
 #          xpdf -remote <server> -exec "openFile(file)"
-    ps_list=psutil.get_pid_list()
+    ps_list=psutil.pids()
     server_file_dict={}
     for pr in ps_list:
         try:

--- a/ftplugin/ATP_files/compile.py
+++ b/ftplugin/ATP_files/compile.py
@@ -283,7 +283,7 @@ def xpdf_server_file_dict():
     #    where get_filename is a simple program which returns the filename.
     #    Then if the file matches I can just reload, if not I can use:
     #          xpdf -remote <server> -exec "openFile(file)"
-    ps_list = psutil.get_pid_list()
+    ps_list = psutil.pids()
     server_file_dict = {}
     for pr in ps_list:
         try:

--- a/ftplugin/ATP_files/makelatex.py
+++ b/ftplugin/ATP_files/makelatex.py
@@ -245,7 +245,7 @@ def xpdf_server_file_dict():
        Then if the file matches I can just reload, if not I can use:
              xpdf -remote <server> -exec "openFile(file)"
      """
-    ps_list = psutil.get_pid_list()
+    ps_list = psutil.pids()
     server_file_dict = {}
     for pr in ps_list:
         try:

--- a/ftplugin/ATP_files/options.vim
+++ b/ftplugin/ATP_files/options.vim
@@ -1691,7 +1691,7 @@ try:
         from psutil import NoSuchProcess, AccessDenied
     except ImportError:
         from psutil.error import NoSuchProcess, AccessDenied
-    for pid in psutil.get_pid_list():
+    for pid in psutil.pids():
         try:
             process = psutil.Process(pid)
             if psutil.version_info[0] >= 2:


### PR DESCRIPTION
This was changed in psutil. See:
https://github.com/giampaolo/psutil/blob/master/HISTORY.rst

Without these changes, atp_vim does not work anymore correctly with recent versions of psutil.