### PR TITLE
Make compatible with Neovim

### DIFF
--- a/autoload/atplib.vim
+++ b/autoload/atplib.vim
@@ -43,7 +43,7 @@ from signal import SIGKILL
 pids=vim.eval("a:pids")
 for pid in pids:
     try:
-	os.kill(int(pid),SIGKILL)
+        os.kill(int(pid),SIGKILL)
     except OSError:
         pass
 END
@@ -642,7 +642,7 @@ function! atplib#ServerListOfFiles()
     return file_list
 endfunction
 fun! atplib#PyLog(file, message,...)
-if !has("python")
+if !has("python") && !has("python3")
     return
 endif
 let mode = a:0 ? a:1 : 'a'

--- a/autoload/atplib.vim
+++ b/autoload/atplib.vim
@@ -35,7 +35,7 @@ function! atplib#KillPIDs(pids,...) "{{{
     if len(a:pids) == 0 && a:0 == 0
 	return
     endif
-pyx << END
+exe (has("python3") ? "python3" : "python") . " << END"
 import os
 import signal
 from signal import SIGKILL
@@ -352,7 +352,7 @@ endif
 endfunction
 fun! atplib#joinpath(path1, path2) " {{{1
     if has("python")
-pyx << EOF
+exe (has("python3") ? "python3" : "python") . " << EOF"
 import vim
 import os.path
 import json
@@ -646,7 +646,7 @@ if !has("python") && !has("python3")
     return
 endif
 let mode = a:0 ? a:1 : 'a'
-pyx << EOF
+exe (has("python3") ? "python3" : "python") . " << EOF"
 import vim
 fname = vim.eval('a:file')
 message = vim.eval('a:message')
@@ -875,7 +875,7 @@ endfunction
 
 " URL query: (by some strange reason this is not working moved to url_query.py)
 " function! atplib#URLquery(url) "{{{
-" pyx << EOF
+" exe (has("python3") ? "python3" : "python") . " << EOF"
 " import urllib2, tempfile, vim
 " url  = vim.eval("a:url") 
 " print(url)

--- a/autoload/atplib/bibsearch.vim
+++ b/autoload/atplib/bibsearch.vim
@@ -433,7 +433,7 @@ for file in files:
     while lnr < file_len:
         lnr+=1
         line=file_l[lnr-1]
-	if re.search('@string', line):
+        if re.search('@string', line):
             continue
         line_without_ligatures=remove_ligatures(line)
         if re.search(pattern, line_without_ligatures):

--- a/autoload/atplib/bibsearch.vim
+++ b/autoload/atplib/bibsearch.vim
@@ -353,7 +353,7 @@ function! atplib#bibsearch#searchbib_py(bang,pattern, bibfiles, ...)
     else
 	let pattern = a:pattern
     endif
-pyx << END
+exe (has("python3") ? "python3" : "python") . " << END"
 import vim
 import re
 import locale
@@ -507,7 +507,7 @@ function! atplib#bibsearch#SearchBibItems()
     call map(l:includefile_list, 'atplib#FullPath(v:val)')
 
     if has("python")
-pyx << PEND
+exe (has("python3") ? "python3" : "python") . " << PEND"
 import vim
 import re
 import atplib.atpvim as atp

--- a/autoload/atplib/callback.vim
+++ b/autoload/atplib/callback.vim
@@ -415,17 +415,17 @@ if len(pids) > 0:
     ps_list=psutil.pids()
     rmpids=[]
     for lp in pids:
-	run=False
-	for p in ps_list:
+        run=False
+        for p in ps_list:
             if str(lp) == str(p):
-		run=True
-		break
-	if not run:
+                run=True
+                break
+        if not run:
             rmpids.append(lp)
     rmpids.sort()
     rmpids.reverse()
     for pid in rmpids:
-	vim.eval("filter("+var+", 'v:val !~ \""+str(pid)+"\"')")
+        vim.eval("filter("+var+", 'v:val !~ \""+str(pid)+"\"')")
 EOL
 endfunction "}}}
 "{{{ atplib#callback#ProgressBar

--- a/autoload/atplib/callback.vim
+++ b/autoload/atplib/callback.vim
@@ -403,7 +403,7 @@ endfunction "}}}
 function! atplib#callback#PIDsRunning(var)
 " a:var is a string, and might be one of 'b:atp_LatexPIDs', 'b:atp_BibtexPIDs' or
 " 'b:atp_MakeindexPIDs'. PIDs that are not running are removed from this list.
-pyx << EOL
+exe (has("python3") ? "python3" : "python") . " << EOL"
 import sys
 import re
 import vim

--- a/autoload/atplib/compiler.vim
+++ b/autoload/atplib/compiler.vim
@@ -332,7 +332,7 @@ endfunction
 " The same but using python (it is not used)
 " TODO: end this.
 function! atplib#compiler#PythonGetPID() 
-pyx << EOF
+exe (has("python3") ? "python3" : "python") . " << EOF"
 import psutil
 try:
     from psutil import NoSuchProcess, AccessDenied
@@ -529,7 +529,7 @@ function! atplib#compiler#IsRunning(program, file, ...)
     endif
 
 let s:return_is_running=0
-pyx << EOF
+exe (has("python3") ? "python3" : "python") . " << EOF"
 import vim
 import psutil
 import os
@@ -864,7 +864,7 @@ function! atplib#compiler#LocalCompiler(mode, runs, ...)
     if a:mode == "n" && subfiles
 	" if subfiles package is used.
 	" compilation is done in the current directory.
-pyx << ENDPYTHON
+exe (has("python3") ? "python3" : "python") . " << ENDPYTHON"
 import vim
 import os
 import os.path
@@ -1376,7 +1376,7 @@ function! atplib#compiler#ThreadedCompiler(bibtex, start, runs, verbose, command
     let autex_wait		= ( b:atp_autex_wait ? ' --autex_wait ' : '') 
     let keep                    = join(g:atp_keep, ',')
 
-pyx << ENDPYTHON
+exe (has("python3") ? "python3" : "python") . " << ENDPYTHON"
 import vim
 import threading
 import sys
@@ -1911,7 +1911,7 @@ function! atplib#compiler#tex()
 " line 3:
 " E121: Undefined variable: a:var 
 " and other similar errors. Mainly (if not only) errors E121.
-pyx << ENDPYTHON
+exe (has("python3") ? "python3" : "python") . " << ENDPYTHON"
 import vim
 import threading
 import sys

--- a/autoload/atplib/compiler.vim
+++ b/autoload/atplib/compiler.vim
@@ -361,9 +361,9 @@ for pr in ps_list:
         pass
 
 if latex_running:
-	vim.command("let atplib#compiler#var=%s" % latex_pid)
+    vim.command("let atplib#compiler#var=%s" % latex_pid)
 else:
-	vim.command("let atplib#compiler#var=''")
+    vim.command("let atplib#compiler#var=''")
 EOF
 endfunction
 function! atplib#compiler#GetPID()
@@ -1442,7 +1442,7 @@ def latex_progress_bar(cmd):
                 stack.popleft()
             match = re.match('\[(\n?\d(\n|\d)*)({|\])',str(''.join(stack)))
             if match:
-		vim.eval("atplib#callback#ProgressBar(%s,%s,%s)" % (match.group(1)[match.start():match.end()], pid, bufnr))
+                vim.eval("atplib#callback#ProgressBar(%s,%s,%s)" % (match.group(1)[match.start():match.end()], pid, bufnr))
     child.wait()
     vim.eval("atplib#callback#ProgressBar('end',%s,%s)" % (pid, bufnr))
     vim.eval("atplib#callback#PIDsRunning(\"b:atp_LatexPIDs\")")
@@ -1500,7 +1500,7 @@ else:
     aucommand="COM"
 command_opt     = list(filter(nonempty,re.split('\s*,\s*', vim.eval("tex_options"))))
 mainfile_fp     = vim.eval("file")
-bufnr		= vim.eval("bufnr('%')")
+bufnr           = vim.eval("bufnr('%')")
 output_format   = vim.eval("ext")
 if output_format == "pdf":
     extension = ".pdf"
@@ -1960,9 +1960,8 @@ def latex_progress_bar(cmd):
 
 class LatexThread( threading.Thread ):
     def run( self ):
-
         file=vim.eval("b:atp_MainFile")
-	latex_progress_bar(['pdflatex', file])
+        latex_progress_bar(['pdflatex', file])
 LatexThread().start()
 ENDPYTHON
 endfunction "}}}

--- a/autoload/atplib/complete.vim
+++ b/autoload/atplib/complete.vim
@@ -1173,7 +1173,7 @@ endfunction
 " a:bracket_dict is a dictionary of brackets to use: 
 " 	 	{ open_bracket : close_bracket } 
 fun! atplib#complete#CheckBracket(bracket_dict) "{{{2
-    if has("python")
+    if has("python") || has("python3")
 	return atplib#complete#CheckBracket_py(a:bracket_dict)
     else
 	return atplib#complete#CheckBracket_vim(a:bracket_dict)
@@ -1187,7 +1187,7 @@ let begin_line = limit_line
 let end_line = min([line('$'), line(".")+g:atp_completion_limits[4]])
 call cursor(pos[1:2])
 let e_pos = []
-if !has("python")
+if !has("python") && !has("python3")
     echoh ErrorMsg
     echom "[ATP:] compile vim with python support for closing brackets"
     echohl Normal
@@ -1631,7 +1631,7 @@ function! atplib#complete#GetBracket(append,bracket_dict,...)
     endif
     let g:time_GetBrackets_A=reltimestr(reltime(time))
 
-    if !has("python")
+    if !has("python") && !has("python3")
 	call cursor(pos[1], pos[2])
 	if begParen[1] != 0  || atplib#complete#CheckSyntaxGroups(['texMathZoneX', 'texMathZoneY', 'texMathZoneV', 'texMathZoneW']) || ( a:0 >= 1 && a:1 )
 	    if atplib#complete#CheckSyntaxGroups(['texMathZoneV'])
@@ -2210,7 +2210,7 @@ function! atplib#complete#TabCompletion(expert_mode,...)
 " {{{2 close environments
     if g:atp_completion_method=='close_env'
 	" Close one line math
-	if !has("python") && (atplib#complete#CheckClosed_math('texMathZoneV') || 
+	if (!has("python") && !has("python3")) && (atplib#complete#CheckClosed_math('texMathZoneV') || 
 		\ atplib#complete#CheckClosed_math('texMathZoneW') ||
 		\ atplib#complete#CheckClosed_math('texMathZoneX') ||
 		\ b:atp_TexFlavor == 'plaintex' && atplib#complete#CheckClosed_math('texMathZoneY'))
@@ -3068,7 +3068,7 @@ function! atplib#complete#TabCompletion(expert_mode,...)
 	    if !exists("b:ListOfFiles") && !exists("b:TypeDict")
 		call TreeOfFiles(b:atp_MainFile)
 	    endif
-	    if has("python") || has("python3") && g:atp_bibsearch == "python" && pat != ""
+	    if (has("python") || has("python3")) && g:atp_bibsearch == "python" && pat != ""
 		let bibfiles=[]
 		for f in b:ListOfFiles
 		    let type = get(b:TypeDict, f, "NOTYPE")
@@ -3505,7 +3505,7 @@ function! atplib#complete#TabCompletion(expert_mode,...)
 	    endif
 
 	    " Check inline math:
-	    if !has("python") && (atplib#complete#CheckClosed_math('texMathZoneV') || 
+	    if (!has("python") && !has("python3")) && (atplib#complete#CheckClosed_math('texMathZoneV') || 
 			\ atplib#complete#CheckClosed_math('texMathZoneW') ||
 			\ atplib#complete#CheckClosed_math('texMathZoneX') ||
 			\ b:atp_TexFlavor == 'plaintex' && atplib#complete#CheckClosed_math('texMathZoneY'))

--- a/autoload/atplib/complete.vim
+++ b/autoload/atplib/complete.vim
@@ -1193,7 +1193,7 @@ if !has("python") && !has("python3")
     echohl Normal
     return [0, 0, '']
 endif
-pyx << EOF
+exe (has("python3") ? "python3" : "python") . " << EOF"
 import vim
 import atplib.check_bracket
 

--- a/autoload/atplib/fontpreview.vim
+++ b/autoload/atplib/fontpreview.vim
@@ -400,7 +400,7 @@ function! atplib#fontpreview#ShowFonts_vim(fd_file)
     return l:font_commands
 endfunction
 function! atplib#fontpreview#ShowFonts_py(fd_file)
-pyx << END
+exe (has("python3") ? "python3" : "python") . " << END"
 import vim
 import re
 file=vim.eval("a:fd_file")

--- a/autoload/atplib/motion.vim
+++ b/autoload/atplib/motion.vim
@@ -243,7 +243,7 @@ endfunction
 function! atplib#motion#maketoc_py(filename,...)
     " filename is supposed to be b:atp_MainFile
 let s:py_toc = []
-pyx << END
+exe (has("python3") ? "python3" : "python") . " << END"
 import vim
 import fileinput
 import sys

--- a/autoload/atplib/motion.vim
+++ b/autoload/atplib/motion.vim
@@ -264,7 +264,7 @@ if main_dir != '':
 section_pattern         = re.compile(r'[^%]*\\(subsection|section|chapter|part)(\*)?\s*(?:\[|{)')
 shorttitle_pattern      = re.compile(r'[^%]*\\(subsection|section|chapter|part)(\*)?\s*\[')
 subfile_pattern         = re.compile(r'[^%]*\\(input|include|subfile)\s*{([^}]*)}')
-bib_pattern		= re.compile(r'[^%]*\\bibliography\s*{([^}]*)}')
+bib_pattern             = re.compile(r'[^%]*\\bibliography\s*{([^}]*)}')
 
 # the toc list:
 toc = []
@@ -278,9 +278,9 @@ file_list = [[file_name, 'root', 0]]
 
 def map_none(val):
     if val == None:
-	return ''
+        return ''
     else:
-	return val
+        return val
 
 def file_path(fname):
     # add tex extension if the file has no extension,
@@ -314,7 +314,7 @@ def scan_project(fname):
             line = flines[ind]
             secu = re.match(section_pattern, line)
             if secu:
-		# Join lines (find titles if they are spread in more than one line):
+                # Join lines (find titles if they are spread in more than one line):
                 i = 1
                 while i+ind < length and i < 6:
                     line += flines[ind+i]
@@ -343,7 +343,7 @@ def scan_project(fname):
                         toc.append([file_path(fname), ind+1, 'bibliography', re.sub('\s*,\s*',' ',bibf.group(1)), '', '*'])
     except IOError:
         print("[ATP]: cannot open '%s' (cwd='%s')" % (file_path(fname), os.getcwd()))
-	pass
+        pass
 
 
 # add stuff to the toc list.

--- a/autoload/atplib/search.vim
+++ b/autoload/atplib/search.vim
@@ -111,7 +111,7 @@ function! atplib#search#make_defi_dict_py(bang,...)
 
     let defi_dict = {}
  
-pyx << ENDPYTHON
+exe (has("python3") ? "python3" : "python") . " << ENDPYTHON"
 import re
 import subprocess
 import os
@@ -195,7 +195,7 @@ function! atplib#search#GlobalDefi(command) "{{{
 if !has("python")
     return
 endif
-pyx << EOF
+exe (has("python3") ? "python3" : "python") . " << EOF"
 import vim
 import re
 import os
@@ -395,7 +395,7 @@ function! atplib#search#LocalCommands_py(write, ...)
 let atp_LocalCommands = []
 let atp_LocalColors = []
 let atp_LocalEnvironments = []
-pyx << END
+exe (has("python3") ? "python3" : "python") . " << END"
 import re
 import vim
 import os.path
@@ -1754,7 +1754,7 @@ function! atplib#search#findfile(fname, ...)
 let time = reltime()
 let path = ( a:0 >= 1 ? a:1 : &l:path )
 let l:count = ( a:0 >= 2 ? a:2 : 1 )
-pyx << EOF
+exe (has("python3") ? "python3" : "python") . " << EOF"
 import vim
 import os.path
 import glob
@@ -2264,7 +2264,7 @@ let b:TypeDict = {}
 let b:LevelDict = {}
 
 let time=reltime()
-pyx << END_PYTHON
+exe (has("python3") ? "python3" : "python") . " << END_PYTHON"
 import vim
 import re
 import subprocess

--- a/autoload/atplib/search.vim
+++ b/autoload/atplib/search.vim
@@ -140,7 +140,7 @@ if int(vim.eval("preambule_only")) != 0:
         if type_dict[f] == "preambule":
             files.append(f)
     with open(main_file) as sock:
-	main_file_l=sock.read().splitlines()
+        main_file_l=sock.read().splitlines()
     preambule_end=preambule_end(main_file_l)
 else:
     preambule_only=False
@@ -1765,7 +1765,7 @@ fname=vim.eval("a:fname")
 file_list = []
 for p in path.split(","):
     if len(p) >= 2 and p[-2:] == "**":
-	file_list.extend(glob.glob(os.path.join( p[:-2], fname )))
+        file_list.extend(glob.glob(os.path.join( p[:-2], fname )))
     file_list.extend(glob.glob(os.path.join( p, fname )))
 
 vim.command("let file_list=%s" % json.dumps(file_list))
@@ -2303,9 +2303,9 @@ def bufnumber(file):
 
     cdir = os.path.abspath(os.curdir)
     try:
-	os.chdir(project_dir)
+        os.chdir(project_dir)
     except OSError:
-	return 0
+        return 0
     for buf in vim.buffers:
         # This requires that we are in the directory of the main tex file:
         if buf.name == os.path.abspath(file):

--- a/autoload/atplib/tools.vim
+++ b/autoload/atplib/tools.vim
@@ -352,8 +352,8 @@ for fname in files:
     lnr = 0
     for line in file_l:
         lnr += 1
-	matches = re.findall('^(?:[^%]*|\\\\%)\\\\label\s*{\s*([^}]*)\s*}', line)
-	for m in matches:
+        matches = re.findall('^(?:[^%]*|\\\\%)\\\\label\s*{\s*([^}]*)\s*}', line)
+        for m in matches:
             loc_list.append([ lnr, m, fname])
 
 if hasattr(vim, 'bindeval'):

--- a/autoload/atplib/tools.vim
+++ b/autoload/atplib/tools.vim
@@ -340,7 +340,7 @@ function! atplib#tools#generatelabels(filename, ...)
 " We should save all files before.
 " Using this python grep makes twice as fast.
 let loc_list = []
-pyx << EOF
+exe (has("python3") ? "python3" : "python") . " << EOF"
 import vim
 import re
 from atplib.atpvim import readlines

--- a/autoload/atplib/various.vim
+++ b/autoload/atplib/various.vim
@@ -2286,20 +2286,20 @@ import vim
 import tarfile
 import re
 
-file_name	=vim.eval('a:file')
-tar_file	=tarfile.open(file_name, 'r:gz')
+file_name = vim.eval('a:file')
+tar_file = tarfile.open(file_name, 'r:gz')
 def tex(name):
     if re.search('ftplugin/tex_atp\.vim', str(name)):
-	return True
+        return True
     else:
-	return False
+        return False
 member=filter(tex, tar_file.getmembers())[0]
 pfile=tar_file.extractfile(member)
 stamp=""
 for line in pfile.readlines():
     if re.match('\s*"\s+Time\s+Stamp:\s+', line):
-	stamp=line
-	break
+        stamp=line
+        break
 try:
     match=re.match('\s*"\s+Time\s+Stamp:\s+([0-9\-_]*)', stamp)
     stamp=match.group(1)

--- a/autoload/atplib/various.vim
+++ b/autoload/atplib/various.vim
@@ -1422,7 +1422,7 @@ endfunction
 try
 function! atplib#various#ReloadATP(bang)
     if has("python")
-pyx << EOF
+exe (has("python3") ? "python3" : "python") . " << EOF"
 import atplib
 for p in atplib.subpackages:
     try:
@@ -2281,7 +2281,7 @@ function! atplib#various#CompareVersions(new, old)
 endfunction "}}}
 "{{{ atplib#various#GetTimeStamp
 function! atplib#various#GetTimeStamp(file)
-pyx << END
+exe (has("python3") ? "python3" : "python") . " << END"
 import vim
 import tarfile
 import re

--- a/doc/automatic-tex-plugin.txt
+++ b/doc/automatic-tex-plugin.txt
@@ -3132,10 +3132,10 @@ If |g:atp_local_completion| is set to non zero value, then input files will be
 scanned for \def, \newcommand, \newnevironment and \newtheorem commands and
 they will be used for completion (with |atp-:LocalCommands|).  If its value is
 1 then this will be done during first completion, if it is set to 2 then this
-will be done at start up.  The default value is 2 when vim has |+python|
-feature otherwise it is 1.  With |+python| this is done at every time you
-use the completion.
-
+will be done at start up. The default value is 2 when vim has |+python| or
+|+python3| feature otherwise it is 1. With |+python| or |+python3| this is done
+at every time you use the completion.
+ 
 NOTE: if you press <C-X><C-O> but then you changed your mind, the completion
 pop-up menu allows to cancel completion: press <C-p> (i.e.  go up - some
 times more than once) and then press <Space>.

--- a/ftplugin/ATP_files/atplib/atpvim.py
+++ b/ftplugin/ATP_files/atplib/atpvim.py
@@ -10,7 +10,7 @@ def getbuffer(fpath):
     fpath should be a full path of a file.
     """
     for buf in vim.buffers:
-	if buf.name == fpath:
+        if buf.name == fpath:
             return buf
     else:
         return None

--- a/ftplugin/ATP_files/atplib/check_bracket.py
+++ b/ftplugin/ATP_files/atplib/check_bracket.py
@@ -133,7 +133,7 @@ def check_bracket(text, line, col, bracket_dict):
                 print("-- (%d, %s)" % (x, O_BRA))
             if closed == -1:
                 """ We can return here since we skip all the ' ( ... ) ' """
-		lpos =line_pos(text, stack[0][0])
+                lpos =line_pos(text, stack[0][0])
                 if DEBUG:
                     pos = line_pos(text, x)
                     print("break at (%d,%d,%s)" % (pos[0], pos[1], text[x]))
@@ -324,7 +324,7 @@ Theorem. Note that there is the following relation satisfied in
 well as $H$ are supposed to be commutative
 (see~\cite[Sec.~3]{fo-yz:gal-cor-hopf-galois}, for noncommutative
 generalisation see:~\cite{ps:hopf-bigalois,ps:gal-cor-hopf-bigal}). We will
-denote this Hopf algebra by $L(H,A)$. 
+denote this Hopf algebra by $L(H,A)$.
 % It satisfies the following two conditions:  \begin{enumerate} \item[(i)]
 % $A/A^{co\,H}$ becomes a \emph{biGalois extension}, i.e. a left
 % $L(H,A)$-comodule algebra and a right $H$-comodule algebra such that both
@@ -387,7 +387,7 @@ subalgebras and closed generalised quotients to crossed products.
 well as $H$ are supposed to be commutative
 (see~\cite[Sec.~3]{fo-yz:gal-cor-hopf-galois}, for noncommutative
 generalisation see:~\cite{ps:hopf-bigalois,ps:gal-cor-hopf-bigal}). We will
-denote this Hopf algebra by $L(H,A)$. 
+denote this Hopf algebra by $L(H,A)$.
 % It satisfies the following two conditions:  \begin{enumerate} \item[(i)]
 % $A/A^{co\,H}$ becomes a \emph{biGalois extension}, i.e. a left
 % $L(H,A)$-comodule algebra and a right $H$-comodule algebra such that both

--- a/ftplugin/ATP_files/common.vim
+++ b/ftplugin/ATP_files/common.vim
@@ -66,7 +66,7 @@ function! TreeOfFiles(main_file,...) "{{{1
     let flat		= a:0 >= 2	? a:2 : 0	
     let run_nr		= a:0 >= 3	? a:3 : 1 
     let time=reltime()
-    if has("python") && &filetype != "plaintex" && ( !exists("g:atp_no_python") || g:atp_no_python == 0 )
+    if (has("python") || has("python3")) && &filetype != "plaintex" && ( !exists("g:atp_no_python") || g:atp_no_python == 0 )
 	" It was not tested on plaintex files.
 	let [tree, list, types, levels] = atplib#search#TreeOfFiles_py(a:main_file)
     else

--- a/ftplugin/ATP_files/compiler.vim
+++ b/ftplugin/ATP_files/compiler.vim
@@ -7,7 +7,7 @@
 
 if !filereadable("makefile") && !filereadable("Makefile")
     if !exists("b:TypeDict")
-	let b:TypeDict=[]
+	let b:TypeDict={}
     endif
     let s:makeprg=g:atp_Python." ".split(globpath(&rtp, "ftplugin/ATP_files/makelatex.py"), "\n")[0].
 		\ " --texfile ".shellescape(atplib#FullPath(b:atp_MainFile)).

--- a/ftplugin/ATP_files/complete.vim
+++ b/ftplugin/ATP_files/complete.vim
@@ -542,7 +542,7 @@ endif
 if !has("python") && !has("python3")
     return {'options' : []}
 endif
-pyx << EOF
+exe (has("python3") ? "python3" : "python") . " << EOF"
 import vim
 import re
 import subprocess

--- a/ftplugin/ATP_files/complete.vim
+++ b/ftplugin/ATP_files/complete.vim
@@ -279,7 +279,7 @@ endif
 	if !exists("g:atp_local_completion")
 	    " if has("python") then fire LocalCommands on startup (BufEnter) if not
 	    " when needed.
-	    let g:atp_local_completion = ( has("python") ? 2 : 1 )
+	    let g:atp_local_completion = ( (has("python") || has("python3")) ? 2 : 1 )
 	endif
 
 
@@ -539,7 +539,7 @@ endfor
 if modes_dict['options'] == 0 && modes_dict['commands'] == 0 && modes_dict['environments'] == 0
     return self
 endif
-if !has("python")
+if !has("python") && !has("python3")
     return {'options' : []}
 endif
 pyx << EOF
@@ -596,14 +596,14 @@ def remove_duplicates(seq, idfun=None):
     # found at http://www.peterbe.com/plog/uniqifiers-benchmark
     # order preserving
     if idfun is None:
-	def idfun(x): return x
+        def idfun(x): return x
     seen = {}
     result = []
     for item in seq:
-	marker = idfun(item)
-	if marker in seen: continue
-	seen[marker] = 1
-	result.append(item)
+        marker = idfun(item)
+        if marker in seen: continue
+        seen[marker] = 1
+        result.append(item)
     return result
 
 def Kpsewhich(package):
@@ -627,9 +627,9 @@ def ScanPackage(package, o=True, c=True, e=True):
         vim.command("let path='%s'" % str(package_file))
         if package_file[-1] in ['\n', '\r']:
             package_file = package_file[:-1]
-	try:
+        try:
             with open(package_file, 'r') as fo:
-		package_f  = fo.read()
+                package_f  = fo.read()
         except IOError as err:
             vim.command('echom "[ATP:] (%r) error: [%s]"' % (package_file,err))
             package_f = ""
@@ -652,9 +652,9 @@ def ScanPackage(package, o=True, c=True, e=True):
             for match in matches:
                 for m in match:
                     if (not '@' in m and not '\\' in m and
-			not re.match('Declare\w*(?:Command|Option)', m) and m != ''):
+                        not re.match('Declare\w*(?:Command|Option)', m) and m != ''):
                         commands.append(re.match('(\S*)', m).group(1))
-	if e:
+        if e:
             vim.command("echomsg '[ATP]: processing environments from %s'" % package)
             matches = re.findall(environment_pat, package_f)
             for match in matches:
@@ -696,13 +696,13 @@ def RecursiveSearch(package):
     recursive_dict[package]=(remove_duplicates(re_commands_add),
                             remove_duplicates(re_environments_add))
     for c in re_commands_add:
-	if not c in re_commands:
+        if not c in re_commands:
             re_commands.append(c)
     for e in re_environments_add:
         if not e in re_environments:
             re_environments.append(e)
     for p in i_files:
-	if not p in did_files:
+        if not p in did_files:
             RecursiveSearch(p)
 
 

--- a/ftplugin/ATP_files/options.vim
+++ b/ftplugin/ATP_files/options.vim
@@ -2783,8 +2783,8 @@ except ImportError:
     vim.command('echomsg "You can get it from: http://code.google.com/p/psutil/"')
     test=vim.eval("has('mac')||has('macunix')||has('unix')")
     if test != str(0):
-	vim.command('echomsg "Falling back to bash"')
-	vim.command("let g:atp_Compiler='bash'")
+        vim.command('echomsg "Falling back to bash"')
+        vim.command("let g:atp_Compiler='bash'")
     vim.command("echohl None")
     vim.command("echomsg \"If you don't want to see this message (and you are on *nix system)\"") 
     vim.command("echomsg \"put let g:atp_Compiler='bash' in your vimrc or atprc file.\"")

--- a/ftplugin/ATP_files/options.vim
+++ b/ftplugin/ATP_files/options.vim
@@ -12,7 +12,7 @@ let s:did_options 	= exists("s:did_options") ? 1 : 0
 
 if has("python") || has("python3")
 let atp_path = fnamemodify(expand('<sfile>'), ':p:h')
-pyx << EOF
+exe (has("python3") ? "python3" : "python") . " << EOF"
 import vim
 import sys
 sys.path.insert(0, vim.eval('atp_path'))
@@ -1675,7 +1675,7 @@ nnoremap <silent> <buffer> <Plug>SetEvince	:call <SID>SetPdf('evince')<CR>
 nnoremap <silent> <buffer> <Plug>SetZathura	:call <SID>SetPdf('zathura')<CR>
 
 function! <SID>Kill_Evince_Sync()
-pyx << EOF
+exe (has("python3") ? "python3" : "python") . " << EOF"
 try:
     import psutil
     import vim
@@ -2210,7 +2210,7 @@ if !s:did_options
     if executable("rmdir")
 	call system("rmdir ".shellescape(a:dir))
     elseif has("python")
-pyx << EOF
+exe (has("python3") ? "python3" : "python") . " << EOF"
 import os, errno
 dir=vim.eval('a:dir')
 try:
@@ -2774,7 +2774,7 @@ endfunction
 " {{{
 function! <SID>TestPythonLibs()
 let time=reltime()
-pyx << END
+exe (has("python3") ? "python3" : "python") . " << END"
 import vim
 try:
     import psutil
@@ -2818,7 +2818,7 @@ endif
 " Remove g:atp_TempDir tree where log files are stored.
 function! <SID>RmTempDir() "{{{
 if has("python")
-pyx << END
+exe (has("python3") ? "python3" : "python") . " << END"
 import shutil
 temp=vim.eval("g:atp_TempDir")
 shutil.rmtree(temp)

--- a/ftplugin/tex_atp.vim
+++ b/ftplugin/tex_atp.vim
@@ -69,7 +69,7 @@ endif
 " Set Python path.
 if has("python") || has("python3")
 let atp_path = fnamemodify(expand('<sfile>'), ':p:s?tex_atp.vim$?ATP_files?')
-pyx << EOF
+exe (has("python3") ? "python3" : "python") . " << EOF"
 import vim
 import sys
 sys.path.insert(0, vim.eval('atp_path'))


### PR DESCRIPTION
Reverts 91afcf8f623c65a99dfb678b50bb8cb438fe6a10 because it made atp incompatible with NeoVim, unfortunately. `pythonx` is also only available in recent Vim versions.

Please consider merging at least the first commit that solves mixing of tabs and spaces, generating a syntax error with Python 3.

A small contribution to express my gratitude. 